### PR TITLE
Feat/create docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 distTsc 
+ghcr.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:24.13.0-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+
+CMD ["npm", "start"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  web:
+    image: ghcr.io/miku0129/docker-minuterie/minuterie:latest-amd64
+    ports:
+      - "4000:4000"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,9 +28,8 @@
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {
-      "*": ["*", "src/*"]
+      "*": ["./src/*"]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -34,6 +34,7 @@ const config: Configuration = {
     static: path.join(__dirname, "dist"),
     compress: true,
     port: 4000,
+    allowedHosts: ["all"],
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
- remove baseUrl, then declare specific path in tsconfig.json because [Deprecate, remove support for baseUrl](https://github.com/microsoft/TypeScript/issues/62207)

- add a list of allowHosts to fix Invalid Host Header. 
  [Webpack Dev Server External Access - (Fix: Invalid Host Header)](https://dev.to/sanamumtaz/webpack-dev-server-external-access-fix-invalid-host-header-g81)
  [devServer.allowedHosts](https://webpack.js.org/configuration/dev-server/#devserverallowedhosts) 

- add setting for docker-continer to host on VPS. [timer.msano.ovh](https://timer.msano.ovh/)



